### PR TITLE
Add support for UploadedFileFactoryInterface and UriFactoryInterface

### DIFF
--- a/src/Contracts/DiscoverContract.php
+++ b/src/Contracts/DiscoverContract.php
@@ -135,6 +135,42 @@ interface DiscoverContract
     public static function httpStreamFactory(): ?object;
 
     /**
+     * Returns an array with all PSR-17 HTTP Uploaded File Factory implementations discovered. No implementations are instantiated by the discovery process.
+     *
+     * Compatible providers: https://packagist.org/providers/psr/http-factory-implementation
+     *
+     * @return CandidateEntity[] An array of CandidateEntity objects representing all implementations discovered.
+     */
+    public static function httpUploadedFileFactories(): array;
+
+    /**
+     * Returns a PSR-17 HTTP Uploaded File factory, or null if one is not found.
+     *
+     * Compatible libraries: https://packagist.org/providers/psr/http-factory-implementation
+     *
+     * @return null|\Psr\Http\Message\UploadedFileFactoryInterface A PSR-17 HTTP UploadedFile factory, or null if one cannot be found.
+     */
+    public static function httpUploadedFileFactory(): ?object;
+
+    /**
+     * Returns an array with all PSR-17 HTTP Uri Factory implementations discovered. No implementations are instantiated by the discovery process.
+     *
+     * Compatible providers: https://packagist.org/providers/psr/http-factory-implementation
+     *
+     * @return CandidateEntity[] An array of CandidateEntity objects representing all implementations discovered.
+     */
+    public static function httpUriFactories(): array;
+
+    /**
+     * Returns a PSR-17 HTTP Uri factory, or null if one is not found.
+     *
+     * Compatible libraries: https://packagist.org/providers/psr/http-factory-implementation
+     *
+     * @return null|\Psr\Http\Message\UriFactoryInterface A PSR-17 HTTP Uri factory, or null if one cannot be found.
+     */
+    public static function httpUriFactory(): ?object;
+
+    /**
      * Returns a PSR-3 Logger, or null if one is not found.
      *
      * Compatible libraries: https://packagist.org/providers/psr/log-implementation

--- a/src/Discover.php
+++ b/src/Discover.php
@@ -53,6 +53,16 @@ final class Discover implements DiscoverContract
     /**
      * @var string
      */
+    private const PSR_HTTP_UPLOADED_FILE_FACTORY = '\Psr\Http\Message\UploadedFileFactoryInterface';
+
+    /**
+     * @var string
+     */
+    private const PSR_HTTP_URI_FACTORY = '\Psr\Http\Message\UriFactoryInterface';
+
+    /**
+     * @var string
+     */
     private const PSR_LOG = '\Psr\Log\LoggerInterface';
 
     /**
@@ -283,6 +293,66 @@ final class Discover implements DiscoverContract
         }
 
         return self::discover(self::PSR_HTTP_STREAM_FACTORY);
+    }
+
+    public static function httpUploadedFileFactories(): array
+    {
+        $implementationsPackage = '\PsrDiscovery\Implementations\Psr17\UploadedFileFactories';
+
+        if (! class_exists($implementationsPackage)) {
+            throw new SupportPackageNotFoundException('PSR-17 HTTP UploadedFile Factory', 'psr-discovery/http-factory-implementations');
+        }
+
+        self::$extendedCandidates[self::PSR_HTTP_UPLOADED_FILE_FACTORY] ??= $implementationsPackage::allCandidates();
+
+        return self::discoveries(self::PSR_HTTP_UPLOADED_FILE_FACTORY);
+    }
+
+    public static function httpUploadedFileFactory(bool $singleton = false): ?object
+    {
+        $implementationsPackage = '\PsrDiscovery\Implementations\Psr17\UploadedFileFactories';
+
+        if (! class_exists($implementationsPackage)) {
+            throw new SupportPackageNotFoundException('PSR-17 HTTP UploadedFile Factory', 'psr-discovery/http-factory-implementations');
+        }
+
+        self::$candidates[self::PSR_HTTP_UPLOADED_FILE_FACTORY] ??= $implementationsPackage::candidates();
+
+        if ($singleton) {
+            return self::singleton(self::PSR_HTTP_UPLOADED_FILE_FACTORY);
+        }
+
+        return self::discover(self::PSR_HTTP_UPLOADED_FILE_FACTORY);
+    }
+
+    public static function httpUriFactories(): array
+    {
+        $implementationsPackage = '\PsrDiscovery\Implementations\Psr17\UriFactories';
+
+        if (! class_exists($implementationsPackage)) {
+            throw new SupportPackageNotFoundException('PSR-17 HTTP Uri Factory', 'psr-discovery/http-factory-implementations');
+        }
+
+        self::$extendedCandidates[self::PSR_HTTP_URI_FACTORY] ??= $implementationsPackage::allCandidates();
+
+        return self::discoveries(self::PSR_HTTP_URI_FACTORY);
+    }
+
+    public static function httpUriFactory(bool $singleton = false): ?object
+    {
+        $implementationsPackage = '\PsrDiscovery\Implementations\Psr17\UriFactories';
+
+        if (! class_exists($implementationsPackage)) {
+            throw new SupportPackageNotFoundException('PSR-17 HTTP Uri Factory', 'psr-discovery/http-factory-implementations');
+        }
+
+        self::$candidates[self::PSR_HTTP_URI_FACTORY] ??= $implementationsPackage::candidates();
+
+        if ($singleton) {
+            return self::singleton(self::PSR_HTTP_URI_FACTORY);
+        }
+
+        return self::discover(self::PSR_HTTP_URI_FACTORY);
     }
 
     public static function log(bool $singleton = false): ?object


### PR DESCRIPTION
This PR adds support for two missing factories defined by PSR-17:

* [UploadedFileFactoryInterface](https://www.php-fig.org/psr/psr-17/#25-uploadedfilefactoryinterface)
* [UriFactoryInterface](https://www.php-fig.org/psr/psr-17/#26-urifactoryinterface)