### PR TITLE
refactor: catch exceptions thrown by `Composer::satisfies` during `discoveries()`

### DIFF
--- a/src/Discover.php
+++ b/src/Discover.php
@@ -441,10 +441,12 @@ final class Discover implements DiscoverContract
 
         // Try to find a candidate that satisfies the version constraints.
         foreach (self::$extendedCandidates[$interface]->all() as $candidateEntity) {
-            /** @var CandidateEntity $candidateEntity */
-            if (Composer::satisfies(new Version(), $candidateEntity->getPackage(), $candidateEntity->getVersion())) {
-                $discovered[] = $candidateEntity;
-            }
+            try {
+                /** @var CandidateEntity $candidateEntity */
+                if (Composer::satisfies(new Version(), $candidateEntity->getPackage(), $candidateEntity->getVersion())) {
+                    $discovered[] = $candidateEntity;
+                }
+            } catch (Throwable) {}
         }
 
         return $discovered;

--- a/src/Discover.php
+++ b/src/Discover.php
@@ -446,7 +446,8 @@ final class Discover implements DiscoverContract
                 if (Composer::satisfies(new Version(), $candidateEntity->getPackage(), $candidateEntity->getVersion())) {
                     $discovered[] = $candidateEntity;
                 }
-            } catch (Throwable) {}
+            } catch (Throwable) {
+            }
         }
 
         return $discovered;


### PR DESCRIPTION
This pull request adds a try/catch block to the one remaining `Composer::satisfies` call without it.